### PR TITLE
[feature] Custom query added to get all data from solved tickets

### DIFF
--- a/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketController.java
+++ b/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import dev.lin.helpdesk_software_api.dtos.CombinedTicketDTO;
 import dev.lin.helpdesk_software_api.dtos.TicketRequestDTO;
 import dev.lin.helpdesk_software_api.dtos.TicketResponseDTO;
 
@@ -33,6 +34,12 @@ public class TicketController {
     @GetMapping("/{id}")
     public TicketResponseDTO getTicketById(@PathVariable Long id) {
         return ticketServiceImpl.showById(id);
+    }
+
+    @GetMapping("/combined")
+    public ResponseEntity<List<CombinedTicketDTO>> getAllCombinedTickets() {
+        List<CombinedTicketDTO> combinedTickets = ticketService.getAllCombinedTickets();
+        return ResponseEntity.ok(combinedTickets);
     }
 
     @PostMapping("")

--- a/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketRepository.java
+++ b/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketRepository.java
@@ -1,12 +1,23 @@
 package dev.lin.helpdesk_software_api.Ticket;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import dev.lin.helpdesk_software_api.dtos.CombinedTicketDTO;
+
 import java.util.List;
 
 @Repository
 public interface TicketRepository extends JpaRepository<TicketEntity, Long> {
 
     List<TicketEntity> findAllByOrderByCreatedAtAsc();
+
+    @Query("SELECT NEW dev.lin.helpdesk_software_api.dtos.CombinedTicketDTO(t.id, t.description, t.requester.name, a.name, t.status, t.createdAt, s.solvedAt) " +
+           "FROM TicketEntity t " +
+           "LEFT JOIN t.requester r " +
+           "LEFT JOIN SolvedTicketEntity s ON s.ticket = t " +
+           "LEFT JOIN s.attendee a")
+    List<CombinedTicketDTO> findAllCombinedTickets();
 
 }

--- a/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketService.java
+++ b/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketService.java
@@ -1,9 +1,13 @@
 package dev.lin.helpdesk_software_api.Ticket;
 
 import dev.lin.helpdesk_software_api.Implementations.IGenericService;
+import dev.lin.helpdesk_software_api.dtos.CombinedTicketDTO;
 import dev.lin.helpdesk_software_api.dtos.TicketRequestDTO;
 import dev.lin.helpdesk_software_api.dtos.TicketResponseDTO;
 
+import java.util.List;
+
 public interface TicketService extends IGenericService<TicketResponseDTO, TicketRequestDTO> {
     TicketResponseDTO updateTicketStatus(Long ticketId, TicketUpdateRequestDTO dtoRequest);
+    List<CombinedTicketDTO> getAllCombinedTickets();
 }

--- a/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketServiceImpl.java
+++ b/src/main/java/dev/lin/helpdesk_software_api/Ticket/TicketServiceImpl.java
@@ -4,6 +4,7 @@ import dev.lin.helpdesk_software_api.Employee.EmployeeEntity;
 import dev.lin.helpdesk_software_api.Employee.EmployeeRepository;
 import dev.lin.helpdesk_software_api.SolvedTicket.SolvedTicketEntity;
 import dev.lin.helpdesk_software_api.SolvedTicket.SolvedTicketRepository;
+import dev.lin.helpdesk_software_api.dtos.CombinedTicketDTO;
 import dev.lin.helpdesk_software_api.dtos.TicketRequestDTO;
 import dev.lin.helpdesk_software_api.dtos.TicketResponseDTO;
 import dev.lin.helpdesk_software_api.exceptions.EmployeeNotFoundException;
@@ -53,6 +54,11 @@ public class TicketServiceImpl implements TicketService {
         return ticketRepository.findById(id)
                                .map(ticketMapper::toDTO)
                                .orElseThrow(() -> new TicketNotFoundException("Ticket not found. Id " + id + " does not exist."));
+    }
+
+    @Override
+    public List<CombinedTicketDTO> getAllCombinedTickets() {
+        return ticketRepository.findAllCombinedTickets();
     }
 
     @Transactional

--- a/src/main/java/dev/lin/helpdesk_software_api/dtos/CombinedTicketDTO.java
+++ b/src/main/java/dev/lin/helpdesk_software_api/dtos/CombinedTicketDTO.java
@@ -1,0 +1,16 @@
+package dev.lin.helpdesk_software_api.dtos;
+
+import java.time.LocalDateTime;
+
+import dev.lin.helpdesk_software_api.Ticket.TicketStatus;
+
+public record CombinedTicketDTO(
+    Long id,
+    String description,
+    String requesterName,
+    String attendeeName,
+    TicketStatus status,
+    LocalDateTime createdAt,
+    LocalDateTime solvedAt
+) {
+}


### PR DESCRIPTION
A GET query at tickets/combined returns a combination of tickets and solved tickets lines, replacing the requester id and the attendee id for their names from the employees table.